### PR TITLE
Changed NYTimes to lowercase to fix issues with case sensitive file systems.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # logrotate file
 
- [![GoDoc](https://godoc.org/github.com/NYTimes/logrotate?status.svg)](https://godoc.org/github.com/NYTimes/logrotate) [![Build Status](https://travis-ci.org/nytimes/logrotate.svg?branch=master)](https://travis-ci.org/nytimes/logrotate)
+ [![GoDoc](https://godoc.org/github.com/nytimes/logrotate?status.svg)](https://godoc.org/github.com/nytimes/logrotate) [![Build Status](https://travis-ci.org/nytimes/logrotate.svg?branch=master)](https://travis-ci.org/nytimes/logrotate)
 
 `logrotated` can be configured to send a `SIGHUP` signal to a process after rotating it's logs.  This library reopens the underlying `os.File` when a `SIGHUP` is received by the app.
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/NYTimes/logrotate
+module github.com/nytimes/logrotate
 
 go 1.12

--- a/logrotate.go
+++ b/logrotate.go
@@ -1,4 +1,4 @@
-package logrotate // import "github.com/NYTimes/logrotate"
+package logrotate // import "github.com/nytimes/logrotate"
 
 import (
 	"fmt"


### PR DESCRIPTION
This fixes issues with go mod on case sensitive file systems.